### PR TITLE
✨ Find 페이지 데이터 렌더링 1차 완료

### DIFF
--- a/src/app/(public)/[game]/find/page.tsx
+++ b/src/app/(public)/[game]/find/page.tsx
@@ -1,5 +1,7 @@
 import FindPageContent from "@/components/find/FindPageContent";
+import { GetPosts } from "@/services/posts";
 
-export default function page() {
-  return <FindPageContent />;
+export default async function page() {
+  const { posts: postData } = await GetPosts();
+  return <FindPageContent postData={postData} />;
 }

--- a/src/components/common/Fab.tsx
+++ b/src/components/common/Fab.tsx
@@ -4,10 +4,10 @@ import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
 import "@/css/pab.css";
 import FindInfoModal from "../find/FindInfoModal";
-import { postDetailMock } from "@/mocks/post.mock";
-import { sampleMemberType } from "../find/main-card/FindCard";
 import CircleBtn from "./button/CircleBtn";
 import { MessageCircleMore, Plus, Users } from "lucide-react";
+import { postDetailMock } from "@/mocks/post.mock";
+import { sampleMemberType } from "../find/main-card/FindCard";
 
 type View = "actions" | "find" | "chat";
 

--- a/src/components/find/FindMemberCard.tsx
+++ b/src/components/find/FindMemberCard.tsx
@@ -1,31 +1,16 @@
 import { Crown, Minus, Plus } from "lucide-react";
 import Avatar from "../common/Avatar";
-import Image from "next/image";
-import { activePositionIcons, Position } from "@/types/position";
 import CircleBtn from "../common/button/CircleBtn";
 import InviteMemberModal from "./InviteMemberModal";
 import { useInviteStore } from "@/stores/inviteStore";
+import { Participant } from "@/types/post";
 
 type FindMemberCardType = "default" | "modal";
 interface FindMemberCardProps {
   type: FindMemberCardType;
   currentUserId: number;
   masterUser: number;
-  data: {
-    userId: number;
-    nickname: string;
-    profileImageUrl: string;
-    comment: string;
-    gameAccount: {
-      summonerName: string;
-      tag: string;
-      tier: string;
-      winRate: number;
-      kda: number;
-      favoriteChampions: string[];
-      mainPosition: Position;
-    };
-  };
+  data: Participant;
 }
 
 export default function FindMemberCard({
@@ -36,31 +21,23 @@ export default function FindMemberCard({
 }: FindMemberCardProps) {
   const isMaster = currentUserId === masterUser;
   const { openInviteForm } = useInviteStore();
+  const { userId, communityNickname, communityProfileImageUrl, role } = data;
 
   if (data)
     return (
       <div className="bg-accent/10 border-accent/50 flex items-center justify-between rounded-xl border px-4 py-2">
         <div className="flex items-center gap-2">
-          <Avatar type="profile" src={data.profileImageUrl} size="sm" />
+          <Avatar type="profile" src={communityProfileImageUrl} size="sm" />
           <div className="flex items-center">
             <h4 className="flex items-center gap-1 font-bold">
-              {data.gameAccount.summonerName}
-              <span className="text-content-secondary text-sm font-medium">
-                {data.gameAccount.tag}
-              </span>
+              {communityNickname}
             </h4>
           </div>
-          <h5 className="text-accent/50 text-sm">{data.nickname}</h5>
         </div>
-        {masterUser === data.userId ? (
+        {role === "MASTER" ? (
           <Crown size={18} strokeWidth={3} className="text-accent" />
-        ) : type === "default" ? (
-          <Image
-            src={activePositionIcons[data.gameAccount.mainPosition]}
-            alt={`${data.gameAccount.mainPosition} position icon`}
-            height={18}
-          />
         ) : (
+          type === "default" &&
           isMaster && (
             <CircleBtn className="bg-negative hover:bg-negative/50 h-5 w-5">
               <Minus />

--- a/src/components/find/FindPageContent.tsx
+++ b/src/components/find/FindPageContent.tsx
@@ -5,24 +5,27 @@ import ToggleBtn from "@/components/common/button/ToggleBtn";
 import Dropdown from "@/components/common/Dropdown";
 import FindCard from "@/components/find/main-card/FindCard";
 import PositionFilterBtns from "@/components/find/PositionFilterBtns";
-import { postDetailMock } from "@/mocks/post.mock";
 import { useEffect, useState } from "react";
 import FindCreateForm from "./FindCreateForm";
 import FindDetailModal from "./FindDetailModal";
 import { useMenuStore } from "@/stores/menuStore";
+import { Post } from "@/types/post";
+import { Unlink } from "lucide-react";
+import { postListResponseMock } from "@/mocks/post.mock";
 
-export default function FindPageContent() {
+export default function FindPageContent({ postData }: { postData: Post[] }) {
   // 라우팅으로 변경 예정
   const [isOpenFindCreateForm, setIsOpenFindCreateForm] = useState(false);
   const [isOpenFindDetailModal, setIsOpenFindDetailModal] = useState(false);
   const { setMenu } = useMenuStore();
+  const postDataMock = postListResponseMock.posts;
 
   useEffect(() => {
     setMenu("find");
   }, []);
 
   return (
-    <div className="flex flex-col gap-7.5">
+    <div className="flex h-full flex-col gap-7.5">
       <ToggleBtn value="recruiting" onChange={() => {}} className="mt-17.5" />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -79,21 +82,31 @@ export default function FindPageContent() {
           }}
         />
       </div>
-      <div className="flex flex-wrap justify-between gap-y-7.5 px-7.5">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <FindCard
-            key={index}
-            data={postDetailMock}
-            onClick={() => setIsOpenFindDetailModal(true)}
+      {postDataMock.length < 1 ? (
+        <div className="m-auto flex w-full flex-col items-center justify-center gap-10.5">
+          <Unlink size={160} className="text-bg-tertiary" />
+          <p className="text-content-secondary text-[32px] font-bold">
+            등록된 모집글이 없습니다
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-wrap justify-between gap-y-7.5 px-7.5">
+          {postDataMock.map((post, index) => (
+            <FindCard
+              key={index}
+              data={post}
+              onClick={() => setIsOpenFindDetailModal(true)}
+            />
+          ))}
+
+          <FindDetailModal
+            isOpen={isOpenFindDetailModal}
+            onOpenChange={(open: boolean) => {
+              setIsOpenFindDetailModal(open);
+            }}
           />
-        ))}
-        <FindDetailModal
-          isOpen={isOpenFindDetailModal}
-          onOpenChange={(open: boolean) => {
-            setIsOpenFindDetailModal(open);
-          }}
-        />
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/find/main-card/FindCard.tsx
+++ b/src/components/find/main-card/FindCard.tsx
@@ -3,7 +3,7 @@
 import { Headset } from "lucide-react";
 import Avatar from "@/components/common/Avatar";
 import FindCardContainer from "@/components/common/container/FindCardContainer";
-import { PostDetail } from "@/types/post";
+import { Post, PostDetail } from "@/types/post";
 import { twMerge } from "tailwind-merge";
 import TierSet from "@/components/profile/TierSet";
 import { isRank, isTier } from "@/types/tier";
@@ -22,7 +22,7 @@ import SubTitleAndData from "../SubTitleAndData";
 import FindCardMemberDetail from "./FindCardMemberDetail";
 
 interface FindCardProps extends HTMLAttributes<HTMLDivElement> {
-  data: PostDetail;
+  data: Post;
 }
 
 export interface sampleMemberType {
@@ -42,11 +42,35 @@ export interface sampleMemberType {
 }
 
 export default function FindCard({ data, ...props }: FindCardProps) {
+  console.log(data);
   const [isOpen, setIsOpen] = useState(false);
-  const { writer, options, statistics } = data;
-  const [tier, rank] = writer.gameAccount.tier.split(" ");
+  const {
+    createdAt,
+    currentParticipants,
+    gameMode,
+    gameModeId,
+    lookingPositions,
+    memo,
+    mic,
+    myPosition,
+    participants,
+    postId,
+    queueType,
+    recruitCount,
+    status,
+    writer,
+  } = data;
+  const {
+    communityNickname,
+    communityProfileImageUrl,
+    gameAccount,
+    gameSummary,
+    userId,
+  } = writer;
+  const { gameNickname, gameTag, gameType, profileIconUrl } = gameAccount;
+  const { division, favoriteChampions, kda, tier, winRate } = gameSummary;
   const validTier = isTier(tier) ? tier : "UNRANKED";
-  const validRank = isRank(rank) ? rank : "";
+  const validRank = isRank(division) ? division : "";
 
   // 샘플 데이터
 
@@ -55,7 +79,6 @@ export default function FindCard({ data, ...props }: FindCardProps) {
     { id: 1, src: Champion.src, percent: 50 },
     { id: 2, src: Champion.src, percent: 50 },
   ];
-  const userId = writer.userId;
   const members: sampleMemberType[] = [
     {
       userId: 20,
@@ -107,9 +130,6 @@ export default function FindCard({ data, ...props }: FindCardProps) {
     },
   ];
 
-  const filled = statistics.currentMemberCount;
-  const empty = options.recruitCount - filled;
-
   return (
     <div className="flex min-w-110 cursor-pointer flex-col" {...props}>
       <FindCardContainer className="flex flex-col gap-3">
@@ -119,7 +139,7 @@ export default function FindCard({ data, ...props }: FindCardProps) {
               <HoverCard.Trigger asChild>
                 <Avatar
                   type="profile"
-                  src={writer.profileImageUrl}
+                  src={profileIconUrl}
                   size="md"
                   className="cursor-pointer"
                 />
@@ -135,20 +155,18 @@ export default function FindCard({ data, ...props }: FindCardProps) {
 
             <div>
               <div className="flex items-center gap-1">
-                <h3 className="text-lg">{writer.gameAccount.summonerName}</h3>
-                <h3 className="text-content-secondary text-sm">
-                  {writer.gameAccount.tag}
-                </h3>
+                <h3 className="text-lg">{gameNickname}</h3>
+                <h3 className="text-content-secondary text-sm">{gameTag}</h3>
                 <Headset
                   size={18}
                   strokeWidth={3}
                   className={twMerge(
                     "text-content-secondary",
-                    options.mic && "text-accent",
+                    mic && "text-accent",
                   )}
                 />
               </div>
-              <h4 className="text-accent/50 text-sm">{writer.nickname}</h4>
+              <h4 className="text-accent/50 text-sm">{communityNickname}</h4>
             </div>
           </div>
           <TierSet
@@ -160,22 +178,22 @@ export default function FindCard({ data, ...props }: FindCardProps) {
         </div>
 
         <div className="flex flex-col gap-1 px-5">
-          <IntroduceBubble content={options.memo} type="message" />
+          <IntroduceBubble content={memo} type="message" />
           <span className="text-content-secondary text-right text-xs">
-            {formatRelativeTime(statistics.createdAt)}
+            {formatRelativeTime(createdAt)}
           </span>
         </div>
 
         <div className="flex items-center justify-between px-5">
           <PositionSet
             type="my"
-            data={options.myPosition}
+            data={myPosition}
             isActive={true}
             size="default"
           />
           <PositionSet
-            type="looking"
-            data={options.lookingPositions}
+            type="find"
+            data={lookingPositions}
             isActive={true}
             size="default"
           />
@@ -185,16 +203,10 @@ export default function FindCard({ data, ...props }: FindCardProps) {
 
         <div className="flex justify-between gap-10">
           <div className="flex flex-col gap-1">
-            <SubTitleAndData
-              title="승률"
-              data={`${writer.gameAccount.winRate}%`}
-            />
-            <WinRate type="horizontal" winRate={writer.gameAccount.winRate} />
+            <SubTitleAndData title="승률" data={`${winRate}%`} />
+            <WinRate type="horizontal" winRate={winRate} />
           </div>
-          <SubTitleAndData
-            title="KDA"
-            data={writer.gameAccount.kda.toString()}
-          />
+          <SubTitleAndData title="KDA" data={kda.toString()} />
         </div>
 
         <div
@@ -206,11 +218,11 @@ export default function FindCard({ data, ...props }: FindCardProps) {
         >
           <SubTitleAndData
             title="인원"
-            data={`${statistics.currentMemberCount}/${options.recruitCount}`}
+            data={`${currentParticipants}/${recruitCount}`}
           />
           <div className="flex justify-between">
             <div className="flex items-center gap-5">
-              {Array.from({ length: filled }).map((_, i) => (
+              {Array.from({ length: currentParticipants }).map((_, i) => (
                 <svg
                   key={`filledMember${i}`}
                   width="17"
@@ -227,23 +239,25 @@ export default function FindCard({ data, ...props }: FindCardProps) {
                   />
                 </svg>
               ))}
-              {Array.from({ length: empty }).map((_, i) => (
-                <svg
-                  key={`emptyMember${i}`}
-                  width="17"
-                  height="20"
-                  viewBox="0 0 17 20"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M8.32584 2C6.1167 2 4.32584 3.79086 4.32584 6C4.32584 8.20914 6.1167 10 8.32584 10C10.535 10 12.3258 8.20914 12.3258 6C12.3258 3.79086 10.535 2 8.32584 2ZM11.9668 10.7694C13.4008 9.67298 14.3258 7.94452 14.3258 6C14.3258 2.68629 11.6395 0 8.32584 0C5.01213 0 2.32584 2.68629 2.32584 6C2.32584 7.94452 3.25085 9.67298 4.68485 10.7694C3.67937 11.2142 2.75434 11.8436 1.96188 12.636C1.34995 13.248 0.835182 13.939 0.42761 14.6851C-0.324507 16.0619 -0.0177813 17.4657 0.829231 18.4584C1.64464 19.414 2.95086 20 4.32584 20H12.3258C13.7008 20 15.007 19.414 15.8224 18.4584C16.6695 17.4657 16.9762 16.0619 16.2241 14.6851C15.8165 13.939 15.3017 13.248 14.6898 12.636C13.8973 11.8436 12.9723 11.2142 11.9668 10.7694ZM8.32584 12C6.46932 12 4.68885 12.7375 3.37609 14.0503C2.90009 14.5263 2.49977 15.0637 2.18279 15.6439C1.87583 16.2058 1.97485 16.7198 2.35064 17.1602C2.75804 17.6376 3.49168 18 4.32584 18H12.3258C13.16 18 13.8936 17.6376 14.301 17.1602C14.6768 16.7198 14.7758 16.2058 14.4689 15.6439C14.1519 15.0637 13.7516 14.5263 13.2756 14.0503C11.9628 12.7375 10.1824 12 8.32584 12Z"
-                    fill="#62748E"
-                  />
-                </svg>
-              ))}
+              {Array.from({ length: recruitCount - currentParticipants }).map(
+                (_, i) => (
+                  <svg
+                    key={`emptyMember${i}`}
+                    width="17"
+                    height="20"
+                    viewBox="0 0 17 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M8.32584 2C6.1167 2 4.32584 3.79086 4.32584 6C4.32584 8.20914 6.1167 10 8.32584 10C10.535 10 12.3258 8.20914 12.3258 6C12.3258 3.79086 10.535 2 8.32584 2ZM11.9668 10.7694C13.4008 9.67298 14.3258 7.94452 14.3258 6C14.3258 2.68629 11.6395 0 8.32584 0C5.01213 0 2.32584 2.68629 2.32584 6C2.32584 7.94452 3.25085 9.67298 4.68485 10.7694C3.67937 11.2142 2.75434 11.8436 1.96188 12.636C1.34995 13.248 0.835182 13.939 0.42761 14.6851C-0.324507 16.0619 -0.0177813 17.4657 0.829231 18.4584C1.64464 19.414 2.95086 20 4.32584 20H12.3258C13.7008 20 15.007 19.414 15.8224 18.4584C16.6695 17.4657 16.9762 16.0619 16.2241 14.6851C15.8165 13.939 15.3017 13.248 14.6898 12.636C13.8973 11.8436 12.9723 11.2142 11.9668 10.7694ZM8.32584 12C6.46932 12 4.68885 12.7375 3.37609 14.0503C2.90009 14.5263 2.49977 15.0637 2.18279 15.6439C1.87583 16.2058 1.97485 16.7198 2.35064 17.1602C2.75804 17.6376 3.49168 18 4.32584 18H12.3258C13.16 18 13.8936 17.6376 14.301 17.1602C14.6768 16.7198 14.7758 16.2058 14.4689 15.6439C14.1519 15.0637 13.7516 14.5263 13.2756 14.0503C11.9628 12.7375 10.1824 12 8.32584 12Z"
+                      fill="#62748E"
+                    />
+                  </svg>
+                ),
+              )}
             </div>
             <BoxButton
               size="xs"
@@ -257,9 +271,10 @@ export default function FindCard({ data, ...props }: FindCardProps) {
 
       {isOpen && (
         <FindCardMemberDetail
-          userId={userId}
-          postData={data}
-          memberData={members}
+          userId={Number(userId)}
+          currentParticipants={currentParticipants}
+          recruitCount={recruitCount}
+          participantsData={participants}
         />
       )}
     </div>

--- a/src/components/find/main-card/FindCardMemberDetail.tsx
+++ b/src/components/find/main-card/FindCardMemberDetail.tsx
@@ -1,33 +1,34 @@
-import { PostDetail } from "@/types/post";
+import { Participant, Post, PostDetail } from "@/types/post";
 import FindCardContainer from "../../common/container/FindCardContainer";
 import { sampleMemberType } from "./FindCard";
 import FindMemberCard from "@/components/find/FindMemberCard";
 
 export default function FindCardMemberDetail({
   userId,
-  postData,
-  memberData,
+  participantsData,
+  currentParticipants,
+  recruitCount,
 }: {
   userId: number;
-  postData: PostDetail;
-  memberData: sampleMemberType[];
+  participantsData: Participant[];
+  currentParticipants: number;
+  recruitCount: number;
 }) {
-  const { writer, options, statistics } = postData;
   return (
     <FindCardContainer className="flex flex-col gap-5 border-t-0">
       <div className="flex flex-col">
         <h3 className="text-content-primary flex w-full items-center justify-between text-xl font-bold">
           인원 정보
-          <span>{`${statistics.currentMemberCount}/${options.recruitCount}`}</span>
+          <span>{`${currentParticipants}/${recruitCount}`}</span>
         </h3>
       </div>
-      {Array.from({ length: options.recruitCount }).map((_, i) => (
+      {participantsData.map((p, i) => (
         <FindMemberCard
           key={`member${i}`}
           type="default"
-          currentUserId={writer.userId}
+          currentUserId={Number(p.userId)}
           masterUser={userId}
-          data={memberData[i]}
+          data={p}
         />
       ))}
     </FindCardContainer>

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,0 +1,2 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";

--- a/src/mocks/post.mock.ts
+++ b/src/mocks/post.mock.ts
@@ -1,4 +1,90 @@
+import { PostPartyDetail } from "@/types/party";
+import { PostListResponse } from "@/types/post";
 import { PostDetail } from "@/types/post";
+
+export const postListResponseMock: PostListResponse = {
+  posts: [
+    {
+      postId: 123,
+
+      gameModeId: 1,
+      gameMode: "SR",
+
+      queueType: "DUO",
+
+      myPosition: "JUNGLE",
+      lookingPositions: ["MID"],
+
+      mic: true,
+
+      recruitCount: 2,
+      currentParticipants: 1,
+
+      status: "RECRUITING",
+
+      memo: "정글 듀오 구합니다!",
+      createdAt: "2025-12-10T12:30:12",
+
+      writer: {
+        userId: 10,
+
+        communityNickname: "커뮤니티닉네임",
+        communityProfileImageUrl: "",
+
+        gameAccount: {
+          gameType: "LEAGUE_OF_LEGENDS",
+          gameNickname: "게임닉네임",
+          gameTag: "KR1",
+          profileIconUrl:
+            "https://ddragon.leagueoflegends.com/cdn/15.24.1/img/profileicon/1234.png",
+        },
+
+        gameSummary: {
+          tier: "DIAMOND",
+          division: "I",
+          winRate: 70.0, // 해당 파트에서 아직 미구현이라 이렇게 표시해둠
+          kda: 3.78, // 해당 파트에서 아직 미구현이라 이렇게 표시해둠
+          favoriteChampions: ["141", "64", "234"], // 해당 파트에서 아직 미구현이라 이렇게 표시해둠        }
+        },
+      },
+      participants: [
+        {
+          userId: 10,
+          communityNickname: "커뮤니티닉네임",
+          communityProfileImageUrl: "",
+          role: "LEADER",
+        },
+        {
+          userId: 20,
+          communityNickname: "참여자닉네임",
+          communityProfileImageUrl: "https://...",
+          role: "MEMBER",
+        },
+      ],
+    },
+  ],
+  nextCursor: 122,
+  hasNext: true,
+};
+
+export const PostPartyDetailMock: PostPartyDetail = {
+  partyId: 9007199254740991,
+  postId: 9007199254740991,
+  status: "ACTIVE",
+  currentCount: 1073741824,
+  maxCount: 1073741824,
+  createdAt: "2025-12-18T04:48:43.452Z",
+  isJoined: true,
+  members: [
+    {
+      partyMemberId: 9007199254740991,
+      userId: 9007199254740991,
+      nickname: "string",
+      profileImage: "string",
+      role: "LEADER",
+    },
+  ],
+};
 
 export const postDetailMock: PostDetail = {
   postId: 101,

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,0 +1,12 @@
+import { API_BASE } from "@/lib/client";
+import { PostListResponse } from "@/types/post";
+
+export async function GetPosts() {
+  const res = await fetch(`${API_BASE}/api/v1/posts`);
+
+  if (!res.ok) {
+    throw new Error(`getPosts failed(${res.status}): ${res.statusText}`);
+  }
+
+  return (await res.json()) as PostListResponse;
+}

--- a/src/types/party.ts
+++ b/src/types/party.ts
@@ -1,0 +1,41 @@
+export type PartyStatus = "ACTIVE" | "INACTIVE" | "CLOSED" | string;
+export type PartyRole = "LEADER" | "MEMBER" | string;
+
+export interface PostPartyDetail {
+  partyId: number | string;
+  postId: number | string;
+  status: string;
+  currentCount: number;
+  maxCount: number;
+  createdAt: string;
+  isJoined: boolean;
+  members: PostPartyMemberDetail[];
+}
+
+export interface PostPartyMemberDetail {
+  partyMemberId: number | string;
+  userId: number | string;
+  nickname: string;
+  profileImage: string;
+  role: PartyMemberRole;
+}
+
+export type PartyMemberRole = "LEADER" | "MEMBER";
+
+export interface MyPartyListResponse {
+  status: string;
+  message: string;
+  data: {
+    parties: MyPartySummary[];
+  };
+}
+
+export interface MyPartySummary {
+  partyId: number | string;
+  postId: number | string;
+  postTitle: string;
+  gameMode: string;
+  status: PartyStatus;
+  myRole: PartyRole;
+  joinedAt: string;
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,6 +1,56 @@
 import { Position } from "./position";
 
-export type PostState = "RECRUITING" | "FILLED" | "GAME_FINISHED";
+export type QueueType = "DUO" | "FLEX" | string;
+export type PostStatus = "RECRUITING" | "FILLED" | "GAME_FINISHED";
+
+export interface PostListResponse {
+  posts: Post[];
+  nextCursor: number | string | null;
+  hasNext: boolean;
+}
+
+export interface Post {
+  postId: number | string;
+  gameModeId: number | string;
+  gameMode: string;
+  queueType: QueueType;
+  myPosition: Position;
+  lookingPositions: Position[];
+  mic: boolean;
+  recruitCount: number;
+  currentParticipants: number;
+  status: PostStatus;
+  memo: string;
+  createdAt: string; // ISO
+  writer: Writer;
+  participants: Participant[];
+}
+
+export interface Writer {
+  userId: number | string;
+  communityNickname: string;
+  communityProfileImageUrl: string;
+  gameAccount: {
+    gameType: string;
+    gameNickname: string;
+    gameTag: string;
+    profileIconUrl: string;
+  };
+  gameSummary: {
+    tier: string;
+    division: string;
+    winRate: number;
+    kda: number;
+    favoriteChampions: string[];
+  };
+}
+
+export interface Participant {
+  userId: number | string;
+  communityNickname: string;
+  communityProfileImageUrl: string;
+  role: string;
+}
 
 export type PostDetail = {
   postId: number;
@@ -30,7 +80,7 @@ export type PostDetail = {
     duoChampions: null;
   };
   statistics: {
-    status: PostState;
+    status: PostStatus;
     currentMemberCount: number;
     createdAt: string;
     updatedAt: string;


### PR DESCRIPTION
일단 백엔드 데이터 기반 find 첫 화면의 findCard 렌더링까지만. 
모집글 상세 정보, 챔피언 데이터, 파티 멤버, 추가/삭제 버튼 등 수정 필요. Fab 수정 필요.

<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- Find 페이지 데이터 렌더링 1차 완료

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] api로 posts 데이터 잘 받아지는 것 확인
- [x] posts, party 관련 타입 지정
- [x] 현재 db에 데이터 없기 때문에 렌더링 테스트는 목업 데이터로 진행
