### PR TITLE
🐛 이메일 아이디 글자수 제한 확장, 게임 연동 아이디 태그 띄어쓰기 허용

### DIFF
--- a/src/components/myprofile/link/LinkGameIdFormModal.tsx
+++ b/src/components/myprofile/link/LinkGameIdFormModal.tsx
@@ -187,9 +187,12 @@ export default function LinkGameIdFormModal({
                   className="h-10 text-sm"
                   {...register("gameTag", {
                     required: "태그를 입력해주세요.",
+                    validate: (value) =>
+                      value.replace(/\s/g, "").length > 0 ||
+                      "공백만 입력할 수는 없습니다.",
                     pattern: {
-                      value: /^[A-Za-z0-9가-힣]+$/,
-                      message: "태그는 공백 없이 문자/숫자만 입력해주세요.",
+                      value: /^[A-Za-z0-9가-힣 ]+$/,
+                      message: "태그는 문자/숫자만 입력할 수 있습니다.",
                     },
                   })}
                 />

--- a/src/lib/validation/signupSchema.ts
+++ b/src/lib/validation/signupSchema.ts
@@ -3,10 +3,7 @@ import { z } from "zod";
 
 const EmailIdSchema = z
   .string()
-  .regex(
-    /^[a-zA-Z0-9._-]{2,8}$/,
-    "아이디는 2글자 이상, 8글자 이하여야 합니다.",
-  );
+  .regex(/^[a-zA-Z0-9._-]{2,32}$/, "아이디는 2글자 이상이어야 합니다.");
 
 export const sendCodeSchema = z.object({
   email: z
@@ -18,7 +15,7 @@ export const sendCodeSchema = z.object({
         const [id] = email.split("@");
         return EmailIdSchema.safeParse(id).success;
       },
-      { message: "이메일 아이디는 2글자 이상, 8글자 이하여야 합니다." },
+      { message: "이메일 아이디는 2글자 이상이어야 합니다." },
     ),
 });
 
@@ -36,7 +33,7 @@ export const verifyCodeSchema = z.object({
         const [id] = email.split("@");
         return EmailIdSchema.safeParse(id).success;
       },
-      { message: "이메일 아이디는 2글자 이상, 8글자 이하여야 합니다." },
+      { message: "이메일 아이디는 2글자 이상이어야 합니다." },
     ),
 });
 
@@ -50,7 +47,7 @@ export const signUpSchema = z
           const [id] = email.split("@");
           return EmailIdSchema.safeParse(id).success;
         },
-        { message: "이메일 아이디는 2글자 이상, 8글자 이하여야 합니다." },
+        { message: "이메일 아이디는 2글자 이상이어야 합니다." },
       ),
 
     code: z


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 이메일 아이디 글자수 제한 확장, 게임 연동 아이디 태그 띄어쓰기 허용

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 이메일 아이디 글자수 제한 확장 (32자)
- [x] 게임 연동 아이디 태그 띄어쓰기 허용
- [x]

## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->

## 👥 코드 리뷰 요청 사항 (옵션)

<!-- 코드 리뷰 시에 요청받고 싶은 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->
