### PR TITLE
🐛 모집글 컴포넌트에 게임 데이터 연동

### DIFF
--- a/src/components/find/FindPageContent.tsx
+++ b/src/components/find/FindPageContent.tsx
@@ -10,7 +10,6 @@ import { useMenuStore } from "@/stores/menuStore";
 import { Post } from "@/types/post";
 import { Unlink } from "lucide-react";
 import gameIconLol from "@/assets/images/game-icon-lol.png";
-import gameIconAram from "@/assets/images/game-icon-aram.svg";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { QUEUE_TYPES, QUEUE_TYPES_LABEL } from "@/types/party";
@@ -59,13 +58,12 @@ export default function FindPageContent({
             name="gameMode"
             placeholder="게임 모드를 선택해주세요"
             onValueChange={() => {}}
-            value="1"
+            value="SUMMONERS_RIFT"
             items={[
               {
-                value: "1",
+                value: "SUMMONERS_RIFT",
                 label: (
                   <div className="flex items-center gap-2.5">
-                    {" "}
                     <Image
                       src={gameIconLol}
                       alt={`lol icon`}
@@ -73,20 +71,6 @@ export default function FindPageContent({
                       className="object-cover"
                     />
                     <span>소환사의 협곡</span>
-                  </div>
-                ),
-              },
-              {
-                value: "2",
-                label: (
-                  <div className="flex items-center gap-2.5">
-                    <Image
-                      src={gameIconAram}
-                      alt={`aram icon`}
-                      width={20}
-                      className="object-cover"
-                    />
-                    <span>칼바람 나락</span>
                   </div>
                 ),
               },

--- a/src/components/find/main-card/FindCard.tsx
+++ b/src/components/find/main-card/FindCard.tsx
@@ -6,7 +6,7 @@ import FindCardContainer from "@/components/common/container/FindCardContainer";
 import { Post } from "@/types/post";
 import { twMerge } from "tailwind-merge";
 import TierSet from "@/components/profile/TierSet";
-import { isTier, Rank } from "@/types/tier";
+import { isTier, Rank, Tier } from "@/types/tier";
 import IntroduceBubble from "@/components/profile/IntroduceBubble";
 import PositionSet from "./PositionSet";
 import Champion from "@/assets/images/test_champion_thumb.png";
@@ -25,6 +25,11 @@ import { useRouter } from "next/navigation";
 import { useGetPartyDetail } from "@/hooks/useGetPartyDetail";
 import useGetUserProfile from "@/hooks/useGetUserProfile";
 import useGetReviewDistribution from "@/hooks/reviews/useGetReviewDistribution";
+import MostChampion from "@/components/profile/MostChampion";
+import { FormLabelAndContent } from "@/components/common/FormLabelAndContent";
+import Image from "next/image";
+import { useGetFavoriteChampions } from "@/hooks/useGetFavoriteChampions";
+import { useGetRanks } from "@/hooks/useGetRanks";
 
 interface FindCardProps extends HTMLAttributes<HTMLDivElement> {
   currentUserId: number | null;
@@ -44,16 +49,12 @@ export default function FindCard({
   const [isOpenFindDetailModal, setIsOpenFindDetailModal] = useState(false);
   const { createdAt, lookingPositions, memo, mic, myPosition, postId, writer } =
     data;
-  const { userId, communityNickname } = writer;
-  // const { gameNickname, gameTag, profileIconUrl } = gameAccount;
-  // const { division, favoriteChampions, kda, tier, winRate } = gameSummary;
+  const { userId, communityNickname, gameAccount, gameSummary } = writer;
+  const { gameNickname, gameTag, profileIconUrl } = gameAccount;
+  const { division, kda, tier, winRate } = gameSummary;
 
-  const {
-    data: partyData,
-    isLoading: partyDataIsLoading,
-    error: partyDataError,
-    refetch: partyDataRefetch,
-  } = useGetPartyDetail(postId);
+  const { data: partyData, isLoading: partyDataIsLoading } =
+    useGetPartyDetail(postId);
 
   const partyMembers = partyData?.members;
 
@@ -64,38 +65,18 @@ export default function FindCard({
   const { data: reviewDistributionData, isLoading: distLoading } =
     useGetReviewDistribution(Number(userId));
 
-  const isLoading = userDataIsLoading || distLoading;
+  const { data: ChampionData, isLoading: ChampionDataIsLoading } =
+    useGetFavoriteChampions(userData?.gameAccountId ?? 0);
 
-  /* ------------------ writer 데이터 문제 해결 되기 전까지 임시 데이터 ------------------ */
-
-  const gameAccount = {
-    gameNickname: "Hide on bush",
-    gameTag: "KR1",
-    profileIconUrl:
-      "https://ddragon.leagueoflegends.com/cdn/15.24.1/img/profileicon/6.png",
-  };
-
-  const gameSummary = {
-    division: "" as Rank,
-    kda: 9.9,
-    tier: "CHALLENGER",
-    winRate: 80,
-  };
-
-  const { gameNickname, gameTag, profileIconUrl } = gameAccount;
-  const { division, kda, tier, winRate } = gameSummary;
-
-  const champions = [
-    { id: 0, src: Champion.src, percent: 50 },
-    { id: 1, src: Champion.src, percent: 50 },
-    { id: 2, src: Champion.src, percent: 50 },
-  ];
-
-  /* ---------------------------------------------------------------------------------- */
-
-  const validTier = isTier(tier) ? tier : "UNRANKED";
+  const isLoading =
+    partyDataIsLoading ||
+    userDataIsLoading ||
+    distLoading ||
+    ChampionDataIsLoading;
 
   if (isLoading) return null;
+
+  const validTier = isTier(tier) ? tier : "UNRANKED";
 
   return (
     <>
@@ -146,8 +127,8 @@ export default function FindCard({
               </div>
             </div>
             <TierSet
-              tier={validTier}
-              rank={division}
+              tier={validTier as Tier}
+              rank={division as Rank}
               type="mini"
               className="inline-flex w-fit text-xs [&>img]:w-12.5"
             />
@@ -173,16 +154,29 @@ export default function FindCard({
               isActive={false}
               size="default"
             />
-            {/* <MostChampion data={champions} type="mastery" size="sm" /> */}
-            {/* <MostChampion data={writer.gameAccount.favoriteChampions} />  */}
+
+            <div className="flex flex-col items-center justify-center gap-2 font-semibold">
+              <p className="text-sm">선호 챔피언</p>
+              <MostChampion data={ChampionData!} />
+            </div>
           </div>
 
           <div className="flex justify-between gap-10">
-            <div className="flex flex-col gap-1">
-              <SubTitleAndData title="승률" data={`${winRate}%`} />
-              <WinRate type="horizontal" winRate={winRate} win={0} lose={0} />
+            <div className="flex w-full flex-col gap-1">
+              <SubTitleAndData title="승률" data={`${winRate ?? 0}%`} />
+              {winRate ? (
+                <WinRate type="horizontal" winRate={winRate} win={0} lose={0} />
+              ) : (
+                <p className="text-content-secondary text-center text-sm">
+                  승률 데이터가 없습니다
+                </p>
+              )}
             </div>
-            <SubTitleAndData title="KDA" data={kda.toString()} />
+            <SubTitleAndData
+              title="KDA"
+              data={kda ? kda.toString() : "0"}
+              className="w-27.5"
+            />
           </div>
 
           <div

--- a/src/components/profile/MostChampion.tsx
+++ b/src/components/profile/MostChampion.tsx
@@ -3,11 +3,11 @@ import Avatar from "../common/Avatar";
 import { cva, VariantProps } from "class-variance-authority";
 import { Champion } from "@/types/game-account";
 
-const container = cva("text-content-primary flex flex-col", {
+const container = cva("flex flex-col", {
   variants: {
     size: {
-      sm: "w-34 h-17",
-      lg: "w-55 h-28",
+      sm: "w-34 ",
+      lg: "w-55",
     },
   },
   defaultVariants: {
@@ -15,17 +15,6 @@ const container = cva("text-content-primary flex flex-col", {
   },
 });
 
-const title = cva("font-semibold", {
-  variants: {
-    size: {
-      sm: "text-sm text-center mb-2",
-      lg: "text-xl text-start mb-4.5",
-    },
-  },
-  defaultVariants: {
-    size: "sm",
-  },
-});
 interface MostChampionProps extends VariantProps<typeof container> {
   data: Champion[];
   className?: string;
@@ -36,17 +25,33 @@ export default function MostChampion({
   data,
   className,
 }: MostChampionProps) {
+  console.log(data);
   return (
     <div className={twMerge(container({ size }), className)}>
       <div className="flex items-center justify-between">
         {data?.map((champ) => (
-          <Avatar
-            key={champ.championId}
-            type="champion"
-            src={champ.championImageUrl}
-            alt={champ.championName}
-            size={size === "sm" ? "sm" : "lg"}
-          />
+          <div key={champ.championId} className="relative flex">
+            {" "}
+            <Avatar
+              key={champ.championId}
+              type="champion"
+              src={champ.championImageUrl}
+              alt={champ.championName}
+              size={size === "sm" ? "sm" : "lg"}
+            />
+            <div className="bg-bg-secondary absolute right-0 bottom-0 flex items-center justify-center">
+              <span
+                className={twMerge(
+                  "text-accent px-1 py-0.5 text-[8px]",
+                  size === "lg" && "px-1.5 text-[11px]",
+                  champ.winRate < 50 && "text-negative",
+                  champ.winRate < 25 && "text-content-secondary",
+                )}
+              >
+                {Math.round(champ.winRate)}%
+              </span>
+            </div>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 모집글 컴포넌트에 게임 데이터 연동

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 랭크, 승률, kda 등 랭크 게임 관련 데이터는 post 데이터 사용
- [x] 선호 챔피언은 모든 게임 관련 데이터 → 선호 챔피언 조회 api로 받아온 데이터 사용
- [x] 각각 데이터 없을 경우 "~ 데이터가 없습니다" 텍스트 렌더링
