### PR TITLE
🐛 비로그인 상태일시 /me api 호출 X, 로그인 한 유저만 차단 버튼 노출

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -15,7 +15,7 @@ export default async function Layout({
       <div className="m-auto w-(--content-area) max-w-full flex-1">
         <main className="h-full w-full">{children}</main>
       </div>
-      <Fab />
+      <Fab currentUserData={userData} />
     </div>
   );
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -15,7 +15,7 @@ export default async function Layout({
       <div className="m-auto w-(--content-area) max-w-full flex-1">
         <main className="h-full w-full">{children}</main>
       </div>
-      <Fab />
+      <Fab currentUserData={userData} />
     </div>
   );
 }

--- a/src/app/(public)/profile/[id]/page.tsx
+++ b/src/app/(public)/profile/[id]/page.tsx
@@ -1,5 +1,9 @@
 import ProfilePageContent from "@/components/profile/ProfilePageContent";
-import { getOtherGameAccount, getUserProfile } from "@/services/users";
+import {
+  getMyProfile,
+  getOtherGameAccount,
+  getUserProfile,
+} from "@/services/users";
 
 export default async function ProfilePage({
   params,
@@ -7,6 +11,7 @@ export default async function ProfilePage({
   params: { id: string };
 }) {
   const { id } = await params;
+  const currentUserData = await getMyProfile();
   const profileData = await getUserProfile(id);
   const gameAccountData = await getOtherGameAccount(
     profileData?.gameAccountId ?? 0,
@@ -16,6 +21,7 @@ export default async function ProfilePage({
     <ProfilePageContent
       profileData={profileData}
       gameAccountData={gameAccountData}
+      currentUserData={currentUserData}
     />
   );
 }

--- a/src/components/common/Fab.tsx
+++ b/src/components/common/Fab.tsx
@@ -6,10 +6,15 @@ import "@/css/pab.css";
 import FindInfoModal from "../find/FindInfoModal";
 import CircleBtn from "./button/CircleBtn";
 import { MessageCircleMore, Plus, Users } from "lucide-react";
+import { MyProfile } from "@/types/profile";
 
 type View = "actions" | "find" | "chat";
 
-export function Fab() {
+export function Fab({
+  currentUserData,
+}: {
+  currentUserData: MyProfile | null;
+}) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [view, setView] = React.useState<View>("actions");
 
@@ -56,7 +61,7 @@ export function Fab() {
                   </CircleBtn>
                 </>
               ) : view === "find" ? (
-                <FindInfoModal />
+                <FindInfoModal currentUserData={currentUserData} />
               ) : (
                 <></>
               )}

--- a/src/components/find/FindInfoModal.tsx
+++ b/src/components/find/FindInfoModal.tsx
@@ -12,9 +12,14 @@ import FindMemberCard from "./main-card/FindMemberCard";
 import { useMyParties } from "@/hooks/useMyParties";
 import { Unlink } from "lucide-react";
 import { QUEUE_TYPES_LABEL } from "@/types/party";
+import { MyProfile } from "@/types/profile";
 
-export default function FindInfoModal() {
-  const { data, isLoading, error, refetch } = useMyParties();
+export default function FindInfoModal({
+  currentUserData,
+}: {
+  currentUserData: MyProfile | null;
+}) {
+  const { data, isLoading, error, refetch } = useMyParties(currentUserData?.id);
 
   const currentPartyData =
     data?.data.parties.filter(

--- a/src/components/find/main-card/FindCard.tsx
+++ b/src/components/find/main-card/FindCard.tsx
@@ -104,6 +104,7 @@ export default function FindCard({
                     className="z-10"
                     userData={userData!}
                     reviewDistributionData={reviewDistributionData!}
+                    currentUserId={currentUserId}
                   />
                 </HoverCard.Content>
               </HoverCard.Root>

--- a/src/components/profile/MiniProfile.tsx
+++ b/src/components/profile/MiniProfile.tsx
@@ -17,12 +17,14 @@ interface MiniProfileProps extends React.ComponentPropsWithoutRef<"div"> {
   userData: UserProfile;
   reviewDistributionData: ReviewDistribution;
   className?: string;
+  currentUserId: number | null;
 }
 
 export default function MiniProfile({
   userData,
   reviewDistributionData,
   className,
+  currentUserId,
 }: MiniProfileProps) {
   const router = useRouter();
 
@@ -31,6 +33,7 @@ export default function MiniProfile({
   const { data: banList, isLoading: isBanListLoading } = useQuery({
     queryKey: ["ban"],
     queryFn: getBanUsersList,
+    enabled: !!currentUserId,
   });
   const banListData = banList ?? [];
   const isUserBlocked = banListData.some((ban) => ban.userId === userData.id);
@@ -80,14 +83,16 @@ export default function MiniProfile({
               {userData.nickname}
             </h3>
           </div>
-          <BoxButton
-            size="xs"
-            tone="negative"
-            text={isUserBlocked ? "차단됨" : "차단하기"}
-            onClick={userBanHandler}
-            className={isUserBlocked ? "pointer-events-none" : ""}
-            disabled={isBanListLoading || banMutation.isPending}
-          />
+          {currentUserId && (
+            <BoxButton
+              size="xs"
+              tone="negative"
+              text={isUserBlocked ? "차단됨" : "차단하기"}
+              onClick={userBanHandler}
+              className={isUserBlocked ? "pointer-events-none" : ""}
+              disabled={isBanListLoading || banMutation.isPending}
+            />
+          )}
         </div>
         <IntroduceBubble
           type="message"

--- a/src/components/profile/MostChampion.tsx
+++ b/src/components/profile/MostChampion.tsx
@@ -25,7 +25,6 @@ export default function MostChampion({
   data,
   className,
 }: MostChampionProps) {
-  console.log(data);
   return (
     <div className={twMerge(container({ size }), className)}>
       <div className="flex items-center justify-between">

--- a/src/components/profile/ProfilePageContent.tsx
+++ b/src/components/profile/ProfilePageContent.tsx
@@ -10,7 +10,7 @@ import ReviewCard from "@/components/review/myprofile/ReviewCard";
 import ReviewPercent from "@/components/review/ReviewPercent";
 import Image from "next/image";
 import LolLogo from "@/assets/images/games/lol/lol-logo.png";
-import { UserProfile } from "@/types/profile";
+import { MyProfile, UserProfile } from "@/types/profile";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { GameAccount } from "@/types/game-account";
@@ -34,9 +34,11 @@ const REFRESH_COOLDOWN_MS = 2 * 60 * 1000;
 export default function ProfilePageContent({
   profileData,
   gameAccountData,
+  currentUserData,
 }: {
   profileData: UserProfile | null;
   gameAccountData: GameAccount | null;
+  currentUserData: MyProfile | null;
 }) {
   const router = useRouter();
 
@@ -63,6 +65,7 @@ export default function ProfilePageContent({
   const { data: banList, isLoading: isBanListLoading } = useQuery({
     queryKey: ["ban"],
     queryFn: getBanUsersList,
+    enabled: !!currentUserData,
   });
   const banListData = banList ?? [];
   const isUserBlocked = banListData.some(
@@ -182,19 +185,21 @@ export default function ProfilePageContent({
                 <span className="text-content-primary text-2xl font-semibold">
                   {nickname}
                 </span>
-                <BoxButton
-                  size="sm"
-                  tone="negative"
-                  className={twMerge(
-                    "w-12 py-3",
-                    isUserBlocked ? "pointer-events-none" : "",
-                  )}
-                  text={isUserBlocked ? "차단됨" : "차단"}
-                  onClick={userBanHandler}
-                  disabled={
-                    isBanListLoading || isUserBlocked || banMutation.isPending
-                  }
-                />
+                {currentUserData && (
+                  <BoxButton
+                    size="sm"
+                    tone="negative"
+                    className={twMerge(
+                      "w-12 py-3",
+                      isUserBlocked ? "pointer-events-none" : "",
+                    )}
+                    text={isUserBlocked ? "차단됨" : "차단"}
+                    onClick={userBanHandler}
+                    disabled={
+                      isBanListLoading || isUserBlocked || banMutation.isPending
+                    }
+                  />
+                )}
               </div>
               <IntroduceBubble size="lg" content={comment} />
             </div>

--- a/src/hooks/useMyParties.ts
+++ b/src/hooks/useMyParties.ts
@@ -1,10 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { getMyParties } from "@/services/party.client";
 import type { MyPartyListResponse } from "@/types/party";
 
-export function useMyParties() {
+export function useMyParties(currentUserId?: number) {
   return useQuery<MyPartyListResponse | null>({
     queryKey: ["me", "parties"],
     queryFn: getMyParties,
+    enabled: currentUserId ? !!currentUserId : false,
   });
 }

--- a/src/services/ban.client.ts
+++ b/src/services/ban.client.ts
@@ -7,7 +7,6 @@ export async function getBanUsersList() {
   });
 
   if (!res.ok) {
-    alert("차단 정보를 불러올 수 없습니다.");
     return null;
   }
 


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 비로그인 상태일시 /me api 호출 X, 로그인 한 유저만 차단 버튼 노출

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] useQuery에 현재 로그인한 유저 정보 유무를 enabled로 설정해서 비로그인 상태일 시 /me api 호출 안 하도록 수정
- [x] 로그인 한 유저에게만 차단 버튼 노출되도록 수정
