### PR TITLE
🐛 시간 표시 형태 맞추기 (백엔드에서 시간 필드들 전부 ISO-8601 + 타임존(오프셋 포함) 형태로 통일했다고 가정)

### DIFF
--- a/src/components/common/chat/ChatBubble.tsx
+++ b/src/components/common/chat/ChatBubble.tsx
@@ -105,9 +105,7 @@ export default function ChatBubble({
                   sideOffset={6}
                   className="bg-bg-quaternary text-content-main rounded-md px-2 py-1 text-xs"
                 >
-                  {new Date(createdAt).toLocaleString("ko-KR", {
-                    timeZone: "Asia/Seoul",
-                  })}
+                  {formatChatTime(createdAt)}
                   <Tooltip.Arrow className="fill-bg-quaternary" />
                 </Tooltip.Content>
               </Tooltip.Portal>

--- a/src/utils/formatChatTime.ts
+++ b/src/utils/formatChatTime.ts
@@ -10,6 +10,6 @@ dayjs.locale("ko");
 const KST = "Asia/Seoul";
 
 export default function formatChatTime(date: string) {
-  // 서버 createdAt(UTC, Z 포함)이 와도 KST로 변환해서 표시
-  return dayjs(date).tz(KST).format("A h:mm"); // 예: 오전 11:18
+  // ISO-8601 + timezone 이 보장되므로 그대로 KST 변환만 하면 됨
+  return dayjs(date).tz(KST).format("A h:mm");
 }


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 현재 채팅 API에서 내려오는 시간 값이 타임존 정보가 없는 형태로 내려오고 있어, 로컬 환경과 배포 환경에서 보여지는 시간이 다름
- 백엔드에 시간 값에 타임존 추가 요청 -> 시간 필드들 전부 ISO-8601 + 타임존(오프셋 포함) 형태로 통일하겠다고 연락 받음
- 이에 맞춰 시간 표시 관련 프론트 코드도 수정

## ✅ 관련 이슈

- X

## 🛠️ 상세 작업 내용

- [x] formatChatTime 유틸 수정
- [x] ChatBubble 수정
