### PR TITLE
🐛 프로필 페이지 및 미니 프로필 차단 처리 수정

### DIFF
--- a/src/components/profile/MiniProfile.tsx
+++ b/src/components/profile/MiniProfile.tsx
@@ -45,19 +45,25 @@ export default function MiniProfile({
         method: "POST",
       });
 
+      let data = null;
+      const contentType = res.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        data = await res.json();
+      }
+
       if (!res.ok) {
-        if (res.status === 400) {
-          showToast.error("자신을 차단할 수 없습니다.");
-          return;
+        // 서버 응답의 에러 코드 활용
+        if (data?.code === "BAN_MYSELF") {
+          throw new Error("자신을 차단할 수 없습니다.");
         }
-        showToast.error("유저 차단에 실패했습니다.");
+        throw new Error("유저 차단에 실패했습니다.");
       }
     },
     onSuccess: () => {
       showToast.success("유저를 차단했습니다.");
       queryClient.invalidateQueries({ queryKey: ["ban"] });
     },
-    onError: (error) => {
+    onError: (error: Error) => {
       showToast.error(error.message);
     },
   });

--- a/src/components/profile/ProfilePageContent.tsx
+++ b/src/components/profile/ProfilePageContent.tsx
@@ -102,12 +102,19 @@ export default function ProfilePageContent({
         method: "POST",
       });
 
-      if (!res.ok) {
-        showToast.error("유저 차단에 실패했습니다.");
-        return;
+      let data = null;
+      const contentType = res.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        data = await res.json();
       }
 
-      showToast.success("유저를 차단했습니다.");
+      if (!res.ok) {
+        // 서버 응답의 에러 코드 활용
+        if (data?.code === "BAN_MYSELF") {
+          throw new Error("자신을 차단할 수 없습니다.");
+        }
+        throw new Error("유저 차단에 실패했습니다.");
+      }
     },
 
     onSuccess: () => {
@@ -115,7 +122,7 @@ export default function ProfilePageContent({
       queryClient.invalidateQueries({ queryKey: ["ban"] });
     },
 
-    onError: (error) => {
+    onError: (error: Error) => {
       showToast.error(error.message);
     },
   });


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 프로필 페이지 및 미니 프로필 차단 처리 수정

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] !res.ok인 경우 return 문 대신 error throw 하기 (return문으로 처리하면 onSuccess가 실행됨)
- [x] 서버 응답 에러 코드 활용
- [x] 중복된 showToast.success 삭제

## 📸 스크린샷 (옵션)
기존 코드 - 나 자신을 차단하는 경우, 상세 설명이 부족한 에러 문구 alert 표시됨, 유저 차단 성공 alert도 함께 표시됨
<img width="623" height="225" alt="image" src="https://github.com/user-attachments/assets/ccee8c1f-3c22-4b4a-8a0b-fa2d697debcf" />
기존 코드 - 타인을 정상적으로 차단하는 경우, 유저 차단 성공 alert가 중복 표시됨
<img width="639" height="222" alt="image" src="https://github.com/user-attachments/assets/76a1a6f7-fc7e-4f55-9961-3bf337ca27b1" />

수정된 코드 - 나 자신을 차단하는 경우, 상세 설명이 포함된 에러 문구 alert 표시됨
<img width="639" height="227" alt="image" src="https://github.com/user-attachments/assets/fd966310-8df3-49ce-a5ba-77b94ef60497" />
수정된 코드 - 타인을 정상적으로 차단하는 경우, 유저 차단 성공 alert가 1개만 표시됨
<img width="640" height="224" alt="image" src="https://github.com/user-attachments/assets/a62eaadf-2427-4006-8e70-eb4d03a1d7b2" />
