### PR TITLE
♻️ 소개글 수정 시 40자 이하 제한 및 동일한 내용으로 수정 제한 적용

### DIFF
--- a/src/components/myprofile/account/CommentSection.tsx
+++ b/src/components/myprofile/account/CommentSection.tsx
@@ -13,6 +13,7 @@ export default function CommentSection({ initialComment }: CommentProps) {
   const [comment, setComment] = useState<string>("");
   const [tempComment, setTempComment] = useState<string>("");
   const [isCommentEditing, setIsCommentEditing] = useState<boolean>(false);
+  const [commentError, setCommentError] = useState<string>("");
 
   const commentInputRef = useRef<HTMLInputElement>(null);
 
@@ -28,6 +29,7 @@ export default function CommentSection({ initialComment }: CommentProps) {
 
   const handleCommentSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (commentError) return;
     try {
       const res = await ClientApi("/api/v1/users/me/comment", {
         method: "PATCH",
@@ -58,10 +60,26 @@ export default function CommentSection({ initialComment }: CommentProps) {
             placeholder={comment}
             className="h-12 py-4 text-base"
           />
+          {commentError && <p className="ml-2 text-sm text-negative">{commentError}</p>}
           <div className="mt-[11px] mr-2 flex gap-4 self-end">
             <button
               type="submit"
               className="text-accent cursor-pointer hover:underline"
+              onClick={() => {
+                setCommentError("");
+                if (comment === tempComment) {
+                  setCommentError(
+                    "변경하려는 소개글이 현재 소개글과 동일합니다.",
+                  );
+                  return;
+                }
+                if (tempComment.length > 40) {
+                  setCommentError(
+                    "소개글은 40자 이하여야 합니다.",
+                  );
+                  return;
+                }
+              }}
             >
               저장
             </button>
@@ -81,7 +99,7 @@ export default function CommentSection({ initialComment }: CommentProps) {
         <div className="flex flex-col gap-2">
           {comment ? (
             <IntroduceBubble
-              content={comment ?? ""}
+              content={comment}
               type="message"
               className="text-sm"
             />
@@ -100,6 +118,7 @@ export default function CommentSection({ initialComment }: CommentProps) {
             onClick={() => {
               setTempComment(comment);
               setIsCommentEditing(true);
+              setCommentError("");
             }}
           />
         </div>


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 소개글 수정 시 40자 이하 제한 및 동일한 내용으로 수정 제한 적용

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 40자 초과하는 소개글 입력 후 저장 버튼 클릭 시 수정 시도 안 되고 경고문구 표시
- [x] 기존 소개글과 동일한 내용 입력 후 저장 버튼 클릭 시 수정 시도 안 되고 경고문구 표시