### PR TITLE
♻️ 모집글의 인원 정보에서 각 유저 커뮤니티 닉네임 클릭 시 해당 유저 프로필 페이지로 진입 가능하도록 구현

### DIFF
--- a/src/components/find/main-card/FindMemberCard.tsx
+++ b/src/components/find/main-card/FindMemberCard.tsx
@@ -53,14 +53,22 @@ export default function FindMemberCard({
   if (PartyMemberData)
     return (
       <div className="bg-accent/10 border-accent/50 flex items-center justify-between rounded-xl border px-4 py-2">
-        <div className="flex items-center gap-2">
+        <div
+          className="group flex items-center gap-2"
+          onClick={(e) => {
+            e.stopPropagation();
+            router.push(`/profile/${PartyMemberData.userId}`);
+          }}
+        >
           <Avatar
             type="profile"
             src={PartyMemberData.profileImage}
             size="sm"
             isBanned={isPartyMemberBanned}
           />
-          <h4 className="font-bold">{PartyMemberData.nickname}</h4>
+          <h4 className="group-hover:text-accent font-bold transition-all duration-150">
+            {PartyMemberData.nickname}
+          </h4>
           {banUsersListIsLoading && (
             <h4 className="">(차단 상태를 불러오는 중)</h4>
           )}


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 모집글의 인원 정보에서 각 유저 커뮤니티 닉네임 클릭 시 해당 유저 프로필 페이지로 진입 가능하도록 구현

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 모집글의 인원 정보에서 각 유저 커뮤니티 닉네임 클릭 시 해당 유저 프로필 페이지로 진입 가능하도록 구현

## 📸 스크린샷 (옵션)
모집글 인원 정보에서 특정 유저의 커뮤니티 닉네임 위에 마우스 hover
<img width="597" height="868" alt="image" src="https://github.com/user-attachments/assets/3ae14d9d-0006-4205-ae2c-4461538aa0b9" />
클릭 후 해당 유저 프로필 페이지 진입
<img width="1887" height="1456" alt="image" src="https://github.com/user-attachments/assets/5363d91c-569a-4f68-80bb-a91d7a36d616" />

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->
