### PR TITLE
🐛 모집글 모달 창에서도 파티원 강퇴 가능, 유저 초대 후 플로팅 다시 열었을 때 초대 창 열려 있던 문제 수정

### DIFF
--- a/src/components/find/main-card/FindMemberCard.tsx
+++ b/src/components/find/main-card/FindMemberCard.tsx
@@ -76,7 +76,6 @@ export default function FindMemberCard({
         {PartyMemberData.role === "LEADER" ? (
           <Crown size={18} strokeWidth={3} className="text-accent" />
         ) : (
-          type === "default" &&
           isLeader && (
             <CircleBtn
               className="bg-negative hover:bg-negative/50 h-5 w-5"

--- a/src/components/find/main-card/FindMemberCard.tsx
+++ b/src/components/find/main-card/FindMemberCard.tsx
@@ -32,7 +32,7 @@ export default function FindMemberCard({
   currentCount,
   maxCount,
 }: FindMemberCardProps) {
-  const { openInviteForm } = useInviteStore();
+  const { openInviteForm, closeInviteForm } = useInviteStore();
   const router = useRouter();
   const qc = useQueryClient();
 
@@ -70,7 +70,7 @@ export default function FindMemberCard({
             {PartyMemberData.nickname}
           </h4>
           {banUsersListIsLoading && (
-            <h4 className="">(차단 상태를 불러오는 중)</h4>
+            <span className="text-sm">(차단 상태를 불러오는 중)</span>
           )}
         </div>
         {PartyMemberData.role === "LEADER" ? (
@@ -85,11 +85,22 @@ export default function FindMemberCard({
                   partyId: partyId,
                   memberId: PartyMemberData.partyMemberId,
                 });
-
+                await qc.invalidateQueries({
+                  queryKey: ["me", "parties"],
+                });
+                await qc.invalidateQueries({
+                  queryKey: [postId, "candidates"],
+                });
+                await qc.invalidateQueries({
+                  queryKey: [postId, "PartyMembers"],
+                });
                 await qc.invalidateQueries({
                   queryKey: [postId, "party"],
                 });
-
+                await qc.invalidateQueries({
+                  queryKey: [postId, "posts"],
+                });
+                closeInviteForm();
                 router.refresh();
               }}
             >


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [이슈번호]type: message -->
<!-- 이슈 없을 시 type: message -->

## 📖 개요

- 모집글 모달 창에서도 파티원 강퇴 가능, 유저 초대 후 플로팅 다시 열었을 때 초대 창 열려 있던 문제 수정

## ✅ 관련 이슈

- Close #이슈 번호

## 🛠️ 상세 작업 내용

- [x] 파티원 강퇴
- [x] 초대 창 열려 있는 문제 수정
